### PR TITLE
Add CODEOWNERS for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — phmatray/TheAppManager
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @phmatray
+
+# Source code (core library)
+/src/ @phmatray
+
+# Tests
+/tests/ @phmatray
+
+# Samples
+/samples/ @phmatray
+
+# CI/CD workflows
+/.github/ @phmatray
+
+# Build and project configuration
+*.sln @phmatray
+*.props @phmatray
+global.json @phmatray
+renovate.json @phmatray
+
+# Documentation
+*.md @phmatray
+LICENSE @phmatray


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file to automatically assign @phmatray as reviewer on pull requests
- Maps specific repository paths (src, tests, samples, CI workflows, build config, docs) to owners
- Resolves health check: **CODEOWNERS** (Tier 2 — Recommended, 2 pts)

## Changes
- New file: `.github/CODEOWNERS` with granular path-to-owner mappings

## Test plan
- [ ] Verify `.github/CODEOWNERS` file exists in the PR
- [ ] Confirm GitHub parses the file without syntax errors (no warning banner on the PR)