### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug to help us improve TheAppManager
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear description of the bug.
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+3. Step three
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS: [e.g., Windows 11, macOS 14, Ubuntu 24.04]
+- .NET Version: [e.g., .NET 8.0, .NET 9.0]
+- TheAppManager Version: [e.g., 1.0.0]
+
+## Additional Context
+Any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: NuGet Package
+    url: https://www.nuget.org/packages/TheAppManager
+    about: View the package on NuGet.org

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for TheAppManager
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+A clear description of the problem this feature would solve.
+
+## Proposed Solution
+Your idea for how to solve it.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Any other context, mockups, or examples.


### PR DESCRIPTION
## Summary
- Add bug report template with .NET-specific environment fields
- Add feature request template with problem/solution structure
- Add config.yml with blank issue option and NuGet link

## Health Check
Resolves **issue-templates** (Tier 2 — Recommended, 2 pts)

## Test plan
- [ ] Verify `.github/ISSUE_TEMPLATE/` directory contains bug_report.md, feature_request.md, and config.yml
- [ ] Confirm "New Issue" on GitHub shows the template chooser