### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+## Related Issue
+
+Fixes #(issue number)
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Refactoring (no functional changes)
+- [ ] Documentation update
+
+## Changes
+
+- Change one
+- Change two
+
+## Checklist
+
+- [ ] My code follows the project's coding style
+- [ ] I have performed a self-review of my code
+- [ ] I have added XML documentation comments where appropriate
+- [ ] I have added or updated tests that prove my fix or feature works
+- [ ] New and existing unit tests pass locally (`dotnet test`)
+- [ ] I have updated the documentation accordingly


### PR DESCRIPTION
## Summary
- Add `.github/pull_request_template.md` to standardize PR descriptions across the project
- Template includes sections for summary, related issue, type of change, changes list, and a .NET-specific review checklist

## Related Backlog Item
Health check: `pr-template` (Tier 2 — Recommended, 2 points)

## Test Plan
- [x] Verify `.github/pull_request_template.md` exists at the standard location
- [ ] Confirm the template renders correctly when opening a new PR on GitHub