### PR TITLE
Enhance Renovate config with .NET-specific rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,1 +1,27 @@
-{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["config:recommended"]}
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":automergeMinor",
+    "schedule:earlyMondays"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Auto-merge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Group all non-major NuGet updates",
+      "matchManagers": ["nuget"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "nuget non-major"
+    },
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Enhance the bare-minimum Renovate config with meaningful customization for a .NET project
- Add automerge for minor/patch updates to reduce manual review burden
- Group NuGet non-major updates into a single PR to reduce PR noise
- Set early Monday schedule and require dashboard approval for major updates

## Changes
- **Schedule**: Early Mondays (`schedule:earlyMondays` preset)
- **Automerge**: Minor and patch updates are auto-merged (`automergeMinor` preset + package rule)
- **Grouping**: All non-major NuGet updates are grouped into a single PR
- **Major updates**: Require dashboard approval before opening a PR
- **Labels**: PRs are labeled with `dependencies`

## Acceptance Criteria
- [x] A Renovate config file exists
- [x] Config includes customization beyond bare defaults (schedule, grouping, auto-merge, and package rules)

## References
- https://docs.renovatebot.com/configuration-options/
- Backlog item: `tier-3--dependency-update-config`