### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Source code
+*.cs text diff=csharp
+*.csproj text
+*.sln text eol=crlf
+*.props text
+*.targets text
+
+# Config
+*.json text
+*.xml text
+*.yml text
+*.yaml text
+*.md text
+
+# Binary
+*.png binary
+*.jpg binary
+*.ico binary
+*.dll binary
+*.exe binary


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` file tailored for .NET/C# projects
- Normalizes line endings across platforms (`* text=auto`)
- Configures C# diff driver for improved diffs on `.cs` files
- Marks binary file types (`.png`, `.jpg`, `.ico`, `.dll`, `.exe`) as binary

## Why
Without `.gitattributes`, line endings are handled inconsistently across platforms. Windows contributors may commit CRLF files, causing noisy diffs and merge conflicts with Linux/macOS contributors. This file also controls GitHub's language statistics and diff behavior for binary files.

## Backlog item
- **Source**: Health Check
- **Tier**: 3 (Nice to Have)
- **Points**: 1