### PR TITLE
Add Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 [![NuGet](https://img.shields.io/nuget/v/TheAppManager.svg)](https://www.nuget.org/packages/TheAppManager)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+## Table of Contents
+
+- [Overview](#overview)
+  - [Architecture](#architecture)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Custom Configuration](#custom-configuration)
+  - [Extending the Default Configuration](#extending-the-default-configuration)
+  - [Async Support](#async-support)
+  - [Builder Configuration Hook](#builder-configuration-hook)
+  - [Advanced: Using AppManagerBuilder](#advanced-using-appmanagerbuilder)
+- [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [License](#license)
+
 ## Overview
 
 TheAppManager provides a clean abstraction (`IAppConfigurationStrategy`) for defining custom startup configurations in ASP.NET Core applications. Using the Strategy pattern, it makes it easy to swap configurations across environments, keep startup logic organized, and reduce boilerplate.


### PR DESCRIPTION
## Summary

- Add a Table of Contents section to the README for quick navigation
- TOC covers all H2 and H3 headings with proper anchor links
- Placed after the badges/description area, before the first content section

## Why

The README is over 5700 bytes but had no Table of Contents, making it harder to navigate. This addresses the `readme-toc` health check (Tier 3).

## Test plan

- [ ] Verify all TOC links resolve to the correct headings
- [ ] Confirm the TOC heading pattern is detected by the health check