### PR TITLE
Align .editorconfig with .NET best practices

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+# EditorConfig for .NET projects
+# https://editorconfig.org
+
 root = true
 
 [*]
@@ -8,32 +11,77 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{csproj,props,targets,xml,json,yml,yaml}]
-indent_size = 2
-
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.{xml,xaml,axaml}]
+indent_size = 2
 
 [*.cs]
 # Organize usings
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
-# Namespace preferences
-csharp_style_namespace_declarations = file_scoped:suggestion
+# this. preferences
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # var preferences
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 
-# Expression-bodied members
+# Expression-level preferences
 csharp_style_expression_bodied_methods = when_on_single_line:suggestion
 csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
 
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# Using preferences
+csharp_using_directive_placement = outside_namespace:suggestion


### PR DESCRIPTION
## Summary

- Aligns `.editorconfig` with the shared .NET reference configuration
- Adds missing style rules: `this.` qualification, language keywords vs BCL types, expression-bodied members (operators, indexers, accessors, lambdas, local functions), pattern matching, null-checking, indentation, spacing, and using directive placement
- Splits combined file-type glob into separate sections for better clarity and coverage (adds `vbproj`, `vcxproj`, `xaml`, `axaml`, `ruleset`, `config`, `nuspec`, `resx`, `vsixmanifest`, `vsct`)

## Test plan

- [ ] Verify `.editorconfig` is correctly picked up by IDE (VS / Rider)
- [ ] Confirm no unintended formatting changes in existing code
- [ ] Run `dotnet format --verify-no-changes` to check current code compliance