### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in TheAppManager, please report it responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use [GitHub's private vulnerability reporting](https://github.com/phmatray/TheAppManager/security/advisories/new) to submit your report, including:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You can expect an initial response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Security Updates
+
+Security updates will be released as patch versions on [NuGet](https://www.nuget.org/packages/TheAppManager). We recommend always using the latest version.
+
+## Scope
+
+This policy covers the TheAppManager NuGet package and its source code hosted at [phmatray/TheAppManager](https://github.com/phmatray/TheAppManager).


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` file to the repository root with a security policy tailored to this .NET library project
- Directs vulnerability reporters to use GitHub's private Security Advisories instead of public issues
- Documents supported versions, scope, and expected response timeline

## Why

Without a security policy, people who discover vulnerabilities have no safe way to report them. They may open a public issue (exposing the vulnerability to attackers) or simply not report it at all.

## Backlog item

Resolves health check `security-md` (Tier 3 — Nice to Have, 1 point).

## Test plan

- [x] `SECURITY.md` exists in the repository root
- [x] Contains vulnerability reporting instructions
- [x] Links to GitHub Security Advisories for private disclosure