### PR TITLE
ci: déclencher la CI sur les PR vers la branche par défaut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Les workflows de ce dépôt filtrent `pull_request` sur une branche qui n'est pas la branche par défaut (`dev`). GitHub n'évalue `pull_request` que si la branche **cible** correspond au filtre : **aucun check ne s'exécute donc jamais** sur une PR vers `dev`, et l'automerge Renovate ne peut pas s'armer faute de check vert.

Cette PR retire le filtre de branche de `pull_request` uniquement. **`push` est laissé strictement inchangé** — le repointer ferait tourner la CI sur la branche par défaut, où un échec préexistant virerait au rouge sans qu'on l'ait choisi.

Fichiers :
- `.github/workflows/ci.yml` — filtre `['main']` retiré

> [!IMPORTANT]
> Le premier build de cette PR peut être le premier de l'histoire du dépôt. S'il est rouge, il ne l'est pas *à cause* de cette PR : la panne existait déjà, rien ne pouvait la signaler. Lors de la vague précédente, **6 dépôts sur 9** étaient dans ce cas.

<sub>Généré par `repo-audit/ci_trigger_fix.py`.</sub>